### PR TITLE
Match `<head>` but not `<header>` in add-script

### DIFF
--- a/src/ring/middleware/refresh.clj
+++ b/src/ring/middleware/refresh.clj
@@ -38,7 +38,7 @@
   (if-let [body-str (as-str body)]
     (str/replace
      body-str
-     #"<head\s*[^>]*>"
+     #"<head\s*(?:\s[^\/>]+)?>"
      #(str % "<script type=\"text/javascript\">" script "</script>"))))
 
 (def ^:private last-modified

--- a/test/ring/middleware/test/refresh.clj
+++ b/test/ring/middleware/test/refresh.clj
@@ -1,6 +1,84 @@
 (ns ring.middleware.test.refresh
-  (:use clojure.test
-        ring.middleware.refresh))
+  (:require [clojure.java.io :as io]
+            [clojure.test :refer [are deftest testing]]
+            [ring.middleware.refresh :refer :all]))
 
-(deftest test-wrap-refresh
-  (is (true? false)))
+(defn- create-test-handler [body]
+  (-> (constantly {:status 200
+                   :headers {"Content-Type" "text/html"}
+                   :body body})
+      wrap-refresh))
+
+(defn- get-test-response-body [handler]
+  (:body (handler {:request-method :get, :uri "/"})))
+
+(def ^:private refresh-script
+  (slurp (io/resource "ring/js/refresh.js")))
+
+(deftest wrap-refresh-adds-script-after-<head>-test
+  (testing "Without a <header> tag"
+   (are [result-body body]
+        (= result-body (get-test-response-body (create-test-handler body)))
+        "<html><body>body</body></html>"
+        "<html><body>body</body></html>"
+
+        "<html><body>body head</body></html>"
+        "<html><body>body head</body></html>"
+
+        "<html><head/><body>body</body></html>"
+        "<html><head/><body>body</body></html>"
+
+        "<html><head /><body>body</body></html>"
+        "<html><head /><body>body</body></html>"
+
+        (str "<html><head>"
+             "<script type=\"text/javascript\">" refresh-script "</script>"
+             "</head><body>body</body></html>")
+        (str "<html><head>"
+             "</head><body>body</body></html>")
+
+        (str "<html><head>"
+             "<script type=\"text/javascript\">" refresh-script "</script>"
+             "<title>title</title></head><body>body</body></html>")
+        (str "<html><head>"
+             "<title>title</title></head><body>body</body></html>")
+
+        (str
+         "<html><head attr=\"val\">"
+         "<script type=\"text/javascript\">" refresh-script "</script>"
+         "<title>title</title></head><body>body</body></html>")
+        (str
+         "<html><head attr=\"val\">"
+         "<title>title</title></head><body>body</body></html>")))
+
+  (testing "With a <header> tag"
+   (are [result-body body]
+        (= result-body (get-test-response-body (create-test-handler body)))
+        "<html><body><header>head</header></body></html>"
+        "<html><body><header>head</header></body></html>"
+
+        "<html><head/><body><header>head</header></body></html>"
+        "<html><head/><body><header>head</header></body></html>"
+
+        "<html><head /><body><header>head</header></body></html>"
+        "<html><head /><body><header>head</header></body></html>"
+
+        (str "<html><head>"
+             "<script type=\"text/javascript\">" refresh-script "</script>"
+             "</head><body><header>head</header></body></html>")
+        (str "<html><head>"
+             "</head><body><header>head</header></body></html>")
+
+        (str "<html><head>"
+             "<script type=\"text/javascript\">" refresh-script "</script>"
+             "<title>t</title></head><body><header>head</header></body></html>")
+        (str "<html><head>"
+             "<title>t</title></head><body><header>head</header></body></html>")
+
+        (str
+         "<html><head attr=\"val\">"
+         "<script type=\"text/javascript\">" refresh-script "</script>"
+         "<title>t</title></head><body><header>head</header></body></html>")
+        (str
+         "<html><head attr=\"val\">"
+         "<title>t</title></head><body><header>head</header></body></html>"))))


### PR DESCRIPTION
Fixes #9

Added tests in 20975cd for a baseline. The first `testing` set passes, and the second set fails. Running the tests with `lein test` requires temporarily bumping Clojure to `1.7.0` or later.

Updated the regex in 2e991ad. All tests pass.