### PR TITLE
Bump Compojure to 1.6.2 to fix Clojure 1.9 warning

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [watchtower "0.1.1"]
-                 [compojure "1.1.5"]])
+                 [compojure "1.6.2"]])


### PR DESCRIPTION
Fixes #11

I verified that the warning shows up as early as Clojure 1.9.0, so I included that in the commit message subject.