### PR TITLE
Update Compojure for Clojure 1.11 compatibility

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,4 +5,4 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [watchtower "0.1.1"]
-                 [compojure "1.6.2"]])
+                 [compojure "1.7.0"]])


### PR DESCRIPTION
Updated Compojure to the recently released `1.7.0` version.

Tests pass.

```sh
$ lein test

lein test ring.middleware.test.refresh

Ran 1 tests containing 13 assertions.
0 failures, 0 errors.
```
