### PR TITLE
Almost complete rewrite

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,2 @@
+{:deps {org.clojure/clojure {:mvn/version "1.10.0"}
+        watchtower/watchtower {:mvn/version "0.1.1"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,2 +1,2 @@
-{:deps {org.clojure/clojure {:mvn/version "1.10.0"}
-        watchtower/watchtower {:mvn/version "0.1.1"}}}
+{:paths ["src" "resources"]
+ :deps {}}

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,0 @@
-(defproject ring-refresh "0.2.0"
-  :description "Ring middleware for automatically refreshing HTML pages"
-  :url "https://github.com/weavejester/ring-refresh"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [watchtower "0.1.1"]
-                 [compojure "1.7.1"]])

--- a/resources/ring/js/refresh.js
+++ b/resources/ring/js/refresh.js
@@ -1,19 +1,29 @@
-var pageLoadTime = new Date().getTime()
+var pageLoadTime = new Date().getTime();
 
-function reloadIfSourceChanged() {
-    var request = new XMLHttpRequest()
-    request.onreadystatechange = function() {
-        if (request.readyState == 4) {
-            if (request.responseText == 'true') {
-                window.location.reload()
+
+async function reloadIfSourceChanged() {
+    try {
+        const response = await fetch('/__source_changed', {
+            method: 'GET',
+            headers: {
+                'Content-Type': 'application/json'
             }
-            else {
-                setTimeout(reloadIfSourceChanged, 200)
-            }
+        });
+        const text = await response.text()
+        const sourceChanged = parseInt(text);
+
+        if (sourceChanged >= pageLoadTime) {
+            console.log("Changed")
+            window.location.reload();
         }
+    } catch (error) {
+        console.error('Error:', error);
     }
-    request.open('GET', '/__source_changed?since=' + pageLoadTime, true)
-    request.send()
 }
 
-window.onload = reloadIfSourceChanged
+async function reloadIfSourceChangedJob() {
+    await reloadIfSourceChanged()
+    setTimeout(reloadIfSourceChangedJob, 200);
+}
+
+window.onload = reloadIfSourceChangedJob;

--- a/resources/ring/js/refresh.js
+++ b/resources/ring/js/refresh.js
@@ -13,7 +13,6 @@ async function reloadIfSourceChanged() {
         const sourceChanged = parseInt(text);
 
         if (sourceChanged >= pageLoadTime) {
-            console.log("Changed")
             window.location.reload();
         }
     } catch (error) {

--- a/src/ring/middleware/refresh.clj
+++ b/src/ring/middleware/refresh.clj
@@ -6,6 +6,14 @@
   (:require [clojure.string :as str]
             [clojure.java.io :as io])
   (:import [java.util Date UUID]))
+(defn- dir-last-modified-ts [dir]
+  (when-let [files (file-seq (io/file dir))]
+    (apply max (map #(.lastModified %) files))))
+
+(defn- dirs-last-modified-ts [dir & dirs]
+  (->> (cons dir dirs)
+       (mapv dir-last-modified-ts)
+       (reduce max)))
 
 (defn- get-request? [request]
   (= (:request-method request) :get))

--- a/src/ring/middleware/refresh.clj
+++ b/src/ring/middleware/refresh.clj
@@ -1,11 +1,7 @@
 (ns ring.middleware.refresh
-  (:refer-clojure :exclude [random-uuid])
-  (:use [compojure.core :only (routes GET)]
-        [watchtower.core :only (watcher rate on-change)]
-        ring.middleware.params)
   (:require [clojure.string :as str]
-            [clojure.java.io :as io])
-  (:import [java.util Date UUID]))
+            [clojure.java.io :as io]))
+
 (defn- dir-last-modified-ts [dir]
   (when-let [files (file-seq (io/file dir))]
     (apply max (map #(.lastModified %) files))))

--- a/src/ring/middleware/refresh.clj
+++ b/src/ring/middleware/refresh.clj
@@ -50,6 +50,8 @@
 
 (defn- random-uuid []
   (str (UUID/randomUUID)))
+     #"</head>"
+     #(str "\n<script type=\"text/javascript\" async>\n" script "</script>\n" %))))
 
 (defn- watch-until [reference pred timeout-ms]
   (let [result    (promise)

--- a/src/ring/middleware/refresh.clj
+++ b/src/ring/middleware/refresh.clj
@@ -15,7 +15,7 @@
   (= (:request-method request) :get))
 
 (defn- html-content? [response]
-  (if-let [content-type (get-in response [:headers "Content-Type"])]
+  (when-let [content-type (get-in response [:headers "Content-Type"])]
     (re-find #"text/html" content-type)))
 
 (def ^:private refresh-script
@@ -37,7 +37,7 @@
   (as-str [_] nil))
 
 (defn- add-script [body script]
-  (if-let [body-str (as-str body)]
+  (when-let [body-str (as-str body)]
     (str/replace
      body-str
      #"<head\s*(?:\s[^\/>]+)?>"


### PR DESCRIPTION
Hi @weavejester, thanks for all you do!

I have tried using ring-refresh in a project with reitit and it didn't work, so I started investigating and making it work and as a result what I got is basically a complete rewrite of the original library 🙈 

I would be grateful if you could take a look. What has changed:

- the js script now uses fetch to get the last save timestamp from endpoint and then compares it to the page loading time
- no watchers or state — each time the endpoint is triggered we check for `.lastModified` of all files in the watched dirs and return the highest value
- no compojure - just handle the `:uri` of the request to see if the `__source_changed` endpoint is called and substitute the handler
- no ring-params and no params
- inject the script before the ending `</head>` to fix #6 
- converted from project.clj to deps.edn

It seems to work ok but I'm sure I must have missed something important, so I'd be grateful for input.